### PR TITLE
Set the spark shuffle partitions to one in the test suite so it runs …

### DIFF
--- a/spark-constraints/test/src/com/nikvanderhoof/spark/sql/constraints/UtestSparkSession.scala
+++ b/spark-constraints/test/src/com/nikvanderhoof/spark/sql/constraints/UtestSparkSession.scala
@@ -4,7 +4,7 @@ import org.apache.spark.sql.SparkSession
 import utest._
 
 trait UtestSparkSession { self: TestSuite =>
-  val spark = SparkSession.builder().master("local[*]").appName("Tests").getOrCreate()
+  val spark = SparkSession.builder().master("local[*]").appName("Tests").config("spark.sql.shuffle.partitions", "1").getOrCreate()
   val sc = spark.sparkContext
   val sql = spark.sqlContext
   sc.setLogLevel("ERROR")


### PR DESCRIPTION
…faster