### PR TITLE
Treat null foreign keys as valid

### DIFF
--- a/spark-constraints/src/com/nikvanderhoof/spark/sql/constraints/constraints.scala
+++ b/spark-constraints/src/com/nikvanderhoof/spark/sql/constraints/constraints.scala
@@ -49,7 +49,10 @@ extends Constraint[T] {
       .zip(refColumns)
       .map { case (a, b) => a === b }
       .fold(lit(true)) { case (acc, next) => acc && next }
-    data.dataset.join(refData.dataset, joinCondition, "leftanti")
+    data
+      .dataset
+      .where(columns.map(_ isNotNull).reduce(_ && _))
+      .join(refData.dataset, joinCondition, "leftanti")
   }
   override def toString: String = {
     val name = data.name

--- a/spark-constraints/test/src/com/nikvanderhoof/spark/sql/constraints/ConstraintTests.scala
+++ b/spark-constraints/test/src/com/nikvanderhoof/spark/sql/constraints/ConstraintTests.scala
@@ -136,6 +136,12 @@ object ConstraintTests extends TestSuite with UtestSparkSession with DataFrameCo
         val constraint = ForeignKey(a, Seq(a("id")), b, Seq(b("id")))
         assert(constraint.holds)
       }
+      "when there are none (nulls do not count)" - {
+        val a = spark.sql("select cast(null as bigint) as id")
+        val b = spark.range(0, 100)
+        val constraint = ForeignKey(a, Seq(a("id")), b, Seq(b("id")))
+        assert(constraint.holds)
+      }
       "when the key is not present in the referenced table" - {
         val a = spark.range(0, 100)
         val b = spark.range(20, 100)


### PR DESCRIPTION
From the postgres documentation:
https://www.postgresql.org/docs/9.4/ddl-constraints.html
In Section 5.3.5
> Normally, a referencing row need not satisfy the foreign key constraint if any of its referencing columns are null.